### PR TITLE
Add hash fields to JSON manifests for Remote tools

### DIFF
--- a/bucket/clipboard-remote.json
+++ b/bucket/clipboard-remote.json
@@ -24,5 +24,6 @@
     },
     "autoupdate": {
         "url": "https://www.ntwind.com/download/ClipboardRemote_$version-win-x64.exe"
-    }
+    },
+    "hash": "90e76a527fa84ff8b0b4a13f31eb55e1aa6430fa893378f235d8becd11a85739"
 }

--- a/bucket/screenshot-remote.json
+++ b/bucket/screenshot-remote.json
@@ -24,5 +24,6 @@
     },
     "autoupdate": {
         "url": "https://www.ntwind.com/download/ScreenshotRemote_$version-win-x64.exe"
-    }
+    },
+    "hash": "86072d03e9519fa4672aea8827342610bd40be7b636324ff4ab686229faa4818"
 }

--- a/bucket/upload-remote.json
+++ b/bucket/upload-remote.json
@@ -24,5 +24,6 @@
     },
     "autoupdate": {
         "url": "https://www.ntwind.com/download/UploadRemote_$version-win-x64.exe"
-    }
+    },
+    "hash": "f1b833bccd4de953a814167f8355d377884847082ca8d6de0ad8fee54f856cdb"
 }


### PR DESCRIPTION
Include hash fields in the JSON manifests for Clipboard, Screenshot, and Upload Remote tools to enhance integrity verification.