### PR TITLE
Fix binary paths in JSON manifest for Hidden Start executables

### DIFF
--- a/bucket/hidden-start.json
+++ b/bucket/hidden-start.json
@@ -27,8 +27,8 @@
         "url": "https://www.ntwind.com/download/Hstart_$version-setup.exe"
     },
     "bin": [
-        ["C:\\Program Files\\Hidden Start\\hstart64.exe", "hstart.exe"],
-        ["C:\\Program Files\\Hidden Start\\hstart.exe", "hstart32.exe"],
-        ["C:\\Program Files\\Hidden Start\\hstart64.exe", "hstart64.exe"]
+        ["C:\\Program Files\\Hidden Start\\hstart64.exe", "hstart"],
+        ["C:\\Program Files\\Hidden Start\\hstart.exe", "hstart32"],
+        ["C:\\Program Files\\Hidden Start\\hstart64.exe", "hstart64"]
     ]
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [ ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
