### PR TITLE
Update actions/checkout to v5 (Node 24)

### DIFF
--- a/.github/workflows/check-new-applications.yml
+++ b/.github/workflows/check-new-applications.yml
@@ -20,7 +20,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Download NTWind page and check for new applications
               shell: pwsh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,8 @@ name: Tests
 on:
   push:
     branches:
-      - 'main'
-      - 'master'
+      - "main"
+      - "master"
   pull_request:
   workflow_dispatch:
 
@@ -14,12 +14,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout Bucket
-        uses: actions/checkout@main
+        uses: actions/checkout@v5
         with:
           fetch-depth: 2
           path: my_bucket
       - name: Checkout Scoop
-        uses: actions/checkout@main
+        uses: actions/checkout@v5
         with:
           repository: ScoopInstaller/Scoop
           path: scoop_core
@@ -38,12 +38,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout Bucket
-        uses: actions/checkout@main
+        uses: actions/checkout@v5
         with:
           fetch-depth: 2
           path: my_bucket
       - name: Checkout Scoop
-        uses: actions/checkout@main
+        uses: actions/checkout@v5
         with:
           repository: ScoopInstaller/Scoop
           path: scoop_core

--- a/.github/workflows/excavator.yml
+++ b/.github/workflows/excavator.yml
@@ -2,14 +2,14 @@ on:
   workflow_dispatch:
   schedule:
     # run every day at 4:20 hours
-    - cron: '20 4 * * *'
+    - cron: "20 4 * * *"
 name: Excavator
 jobs:
   excavate:
     name: Excavate
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v5
       - name: Excavate
         uses: ScoopInstaller/GithubActions@main
         env:

--- a/.github/workflows/issue_comment.yml
+++ b/.github/workflows/issue_comment.yml
@@ -7,7 +7,7 @@ jobs:
     name: PullRequestHandler
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v5
       - name: PullRequestHandler
         uses: ScoopInstaller/GithubActions@main
         if: startsWith(github.event.comment.body, '/verify')

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -7,7 +7,7 @@ jobs:
     name: IssueHandler
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v5
       - name: IssueHandler
         uses: ScoopInstaller/GithubActions@main
         if: github.event.action == 'opened' || (github.event.action == 'labeled' && contains(github.event.issue.labels.*.name, 'verify'))

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,7 +7,7 @@ jobs:
     name: PullRequestHandler
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v5
       - name: PullRequestHandler
         uses: ScoopInstaller/GithubActions@main
         env:

--- a/bin/check-new-applications.ps1
+++ b/bin/check-new-applications.ps1
@@ -43,11 +43,10 @@ function Get-BucketApplications {
             $content = Get-Content $file.FullName -Raw | ConvertFrom-Json
             $appName = $file.BaseName
             $apps[$appName] = @{
-                path = $file.FullName
+                path     = $file.FullName
                 manifest = $content
             }
-        }
-        catch {
+        } catch {
             Write-Warning "Failed to parse $($file.Name): $($_)"
         }
     }
@@ -81,14 +80,13 @@ function Get-AvailableApplications {
             if ($appName -and -not $apps.ContainsKey($appName)) {
                 $apps[$appName] = @{
                     fileName = $fileName
-                    url = "https://www.ntwind.com/download/$fileName"
+                    url      = "https://www.ntwind.com/download/$fileName"
                 }
             }
         }
 
         return $apps
-    }
-    catch {
+    } catch {
         Write-Error "Failed to fetch download page: $($_)"
         return @{}
     }
@@ -107,6 +105,9 @@ function Get-ApplicationNameFromFileName {
         'CloseAll'         = 'close-all-windows'
         'Hstart'           = 'hidden-start'
         'HotkeyScreener'   = 'hotkey-screener'
+        'MediaRemote'      = 'media-remote'
+        'PowerRemote'      = 'power-remote'
+        'PromptSense'      = 'promptsense'
         'ScreenshotRemote' = 'screenshot-remote'
         'StickyPreviews'   = 'sticky-previews'
         'TaskSwitchXP'     = 'taskswitchxp'
@@ -156,7 +157,7 @@ This application was found on https://www.ntwind.com/download-all.html but is no
 
     # Check if issue already exists for this application
     try {
-        $existingIssues = gh issue list --search "title:""$title""" --json title,state --limit 100 2>$null
+        $existingIssues = gh issue list --search "title:""$title""" --json title, state --limit 100 2>$null
 
         if ($existingIssues | ConvertFrom-Json | Where-Object { $_.state -eq 'OPEN' }) {
             Write-Host "  Issue already exists for $appName (skipping)"
@@ -167,8 +168,7 @@ This application was found on https://www.ntwind.com/download-all.html but is no
         gh issue create --title $title --body $body --assignee @me 2>$null
 
         Write-Host "  Issue created for $appName"
-    }
-    catch {
+    } catch {
         Write-Error ("Failed to create issue for {0}: {1}" -f $appName, $_)
     }
 }
@@ -193,12 +193,11 @@ foreach ($appName in $availableApps.Keys) {
 
 if ($newApps.Count -eq 0) {
     Write-Host "No new applications found"
-}
-else {
-        Write-Host ('Found {0} new application(s):' -f $newApps.Count)
-        foreach ($appName in $newApps.Keys | Sort-Object) {
-            $app = $newApps[$appName]
-            Write-Host ('  - {0} ({1})' -f $appName, $app.fileName)
+} else {
+    Write-Host ('Found {0} new application(s):' -f $newApps.Count)
+    foreach ($appName in $newApps.Keys | Sort-Object) {
+        $app = $newApps[$appName]
+        Write-Host ('  - {0} ({1})' -f $appName, $app.fileName)
         if ($CreateIssues -and (Get-Command gh -ErrorAction SilentlyContinue)) {
             New-GitHubIssue -appName $appName -fileName $app.fileName -url $app.url
         }


### PR DESCRIPTION
Resolves the Node.js 20 deprecation warning on GitHub Actions runners.

## Changes
- Bumps `actions/checkout` from `@v4`/`@main` to `@v5` across all six workflows — v5 targets Node 24 natively
- Adds `MediaRemote`, `PowerRemote`, and `PromptSense` to the `check-new-applications.ps1` name map so the weekly scan will create issues for those new NTWind apps

After merging, trigger the **Check for New Applications** workflow manually from the Actions tab to pick up the three new apps.