### PR TITLE
Add power-remote manifest (v1.0.1)

### DIFF
--- a/bucket/power-remote.json
+++ b/bucket/power-remote.json
@@ -1,0 +1,29 @@
+{
+    "version": "1.0.1",
+    "description": "Sleep, wake, lock, or shut down your PC or Mac from your phone or tablet",
+    "homepage": "https://www.ntwind.com/remote/power.html",
+    "license": "Freeware",
+    "url": "https://www.ntwind.com/download/PowerRemote_1.0.1-win-x64.exe",
+    "installer": {
+        "script": [
+            "Start-Process \"$dir\\$fname\" -ArgumentList '/S' -Wait",
+            "Remove-Item \"$dir\\$fname\""
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "$uninstall = Get-ItemProperty HKLM:\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\* | Where-Object {$_.DisplayName -like '*Power Remote*'}",
+            "if ($uninstall) {",
+            "    Start-Process $uninstall.UninstallString -ArgumentList '/S' -Wait",
+            "}"
+        ]
+    },
+    "checkver": {
+        "url": "https://www.ntwind.com/download-all.html",
+        "regex": "PowerRemote_([\\d.]+)-win-x64\\.exe"
+    },
+    "autoupdate": {
+        "url": "https://www.ntwind.com/download/PowerRemote_$version-win-x64.exe"
+    },
+    "hash": "10919946ffd348277aba5664bc1904e804fc1bb8ae9f9eb7c2dc774fb9d99f0c"
+}


### PR DESCRIPTION
Adds a new manifest for **Power Remote** v1.0.1, a free tool from NTWind Software that lets you sleep, wake, lock, restart, or shut down your PC or Mac remotely from a phone, tablet, or another computer over the local network.

- **Homepage**: https://www.ntwind.com/remote/power.html
- **Download**: https://www.ntwind.com/download/PowerRemote_1.0.1-win-x64.exe
- **License**: Freeware
- Includes `checkver` and `autoupdate` support for automatic version tracking

All 26 Pester tests pass.

Closes #25