### PR TITLE
Add media-remote manifest v1.0.1

### DIFF
--- a/bucket/media-remote.json
+++ b/bucket/media-remote.json
@@ -1,0 +1,29 @@
+{
+    "version": "1.0.1",
+    "description": "Cross-platform media remote control tool for Windows, Mac, iOS, and Android",
+    "homepage": "https://www.ntwind.com/remote/media.html",
+    "license": "Proprietary",
+    "url": "https://www.ntwind.com/download/MediaRemote_1.0.1-win-x64.exe",
+    "installer": {
+        "script": [
+            "Start-Process \"$dir\\$fname\" -ArgumentList '/S' -Wait",
+            "Remove-Item \"$dir\\$fname\""
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "$uninstall = Get-ItemProperty HKLM:\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\* | Where-Object {$_.DisplayName -like '*Media Remote*'}",
+            "if ($uninstall) {",
+            "    Start-Process $uninstall.UninstallString -ArgumentList '/S' -Wait",
+            "}"
+        ]
+    },
+    "checkver": {
+        "url": "https://www.ntwind.com/download-all.html",
+        "regex": "MediaRemote_([\\d.]+)-win-x64\\.exe"
+    },
+    "autoupdate": {
+        "url": "https://www.ntwind.com/download/MediaRemote_$version-win-x64.exe"
+    },
+    "hash": "0d037d5df54a1596cfdd5dea5fd87a0dc7abd3b3a116db4ec776c0be011d3056"
+}


### PR DESCRIPTION
Adds a Scoop manifest for NTWind's **Media Remote** application.

Closes #24

## Details
- **Version**: 1.0.1
- **Homepage**: https://www.ntwind.com/remote/media.html
- **Description**: Cross-platform media remote control tool for Windows, Mac, iOS, and Android
- **License**: Proprietary (free, no ads/subscriptions)

## Checklist
- [x] Manifest created following existing patterns (`clipboard-remote.json`, `screenshot-remote.json`)
- [x] JSON formatted with `bin/formatjson.ps1`
- [x] All 26 tests pass (`bin/test.ps1`)
- [x] `checkver` and `autoupdate` configured for automated version tracking