### PR TITLE
Add PromptSense manifest

### DIFF
--- a/bucket/promptsense.json
+++ b/bucket/promptsense.json
@@ -1,0 +1,29 @@
+{
+    "version": "1.0.1",
+    "description": "Organize, reuse, and sync your best AI prompt templates",
+    "homepage": "https://www.ntwind.com/cross-platform/promptsense.html",
+    "license": "Proprietary",
+    "url": "https://www.ntwind.com/download/PromptSense_1.0.1-win-x64.exe",
+    "hash": "c17d817a413b7111c8685915a779147a9e7e19f1036277bd9b1b13f6b970a279",
+    "installer": {
+        "script": [
+            "Start-Process \"$dir\\$fname\" -ArgumentList '/S' -Wait",
+            "Remove-Item \"$dir\\$fname\""
+        ]
+    },
+    "uninstaller": {
+        "script": [
+            "$uninstall = Get-ItemProperty HKLM:\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\* | Where-Object {$_.DisplayName -like '*PromptSense*'}",
+            "if ($uninstall) {",
+            "    Start-Process $uninstall.UninstallString -ArgumentList '/S' -Wait",
+            "}"
+        ]
+    },
+    "checkver": {
+        "url": "https://www.ntwind.com/download-all.html",
+        "regex": "PromptSense_([\\d.]+)-win-x64\\.exe"
+    },
+    "autoupdate": {
+        "url": "https://www.ntwind.com/download/PromptSense_$version-win-x64.exe"
+    }
+}


### PR DESCRIPTION
Closes #26

Adds a Scoop manifest for [PromptSense](https://www.ntwind.com/cross-platform/promptsense.html) v1.0.1 — NTWind's app for organizing, reusing, and syncing AI prompt templates.

## Changes
- `bucket/promptsense.json` — new manifest modeled after `clipboard-remote.json` (same cross-platform `-win-x64.exe` installer pattern)

## Details
- Silent NSIS installer (`/S` flag)
- Registry-based uninstaller lookup
- `checkver` targeting `download-all.html` with regex `PromptSense_([\d.]+)-win-x64\.exe`
- `autoupdate` URL pattern for future version bumps
- All 26 tests pass (`pwsh bin/test.ps1`)